### PR TITLE
Datum conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ scipy
 sealens @ git+https://github.com/oceanmodeling/sealens.git
 seanode @ git+https://github.com/oceanmodeling/seanode.git
 searvey @ git+ssh://git@github.com/oceanmodeling/searvey.git@fix-coops-normalize
-coops-md @ git+https://github.com/oceanmodeling/coops-metadata.git
+coops-md @ git+https://github.com/oceanmodeling/coops-simple-metadata.git
 seastats
 shapely
 stormevents

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ scipy
 sealens @ git+https://github.com/oceanmodeling/sealens.git
 seanode @ git+https://github.com/oceanmodeling/seanode.git
 searvey @ git+ssh://git@github.com/oceanmodeling/searvey.git@fix-coops-normalize
+coops-md @ git+https://github.com/oceanmodeling/coops-metadata.git
 seastats
 shapely
 stormevents

--- a/stofs-event-dashboard/dashboard.py
+++ b/stofs-event-dashboard/dashboard.py
@@ -186,7 +186,12 @@ def load_station_metadata() -> pd.Series[float]:
         metadata = pd.read_json(metadata_path, 
                                 orient='columns', 
                                 typ='series')
-        metadata = metadata * feet_to_meters
+        # TODO: Might need to change this if the metadata file
+        # format is changed.
+        if 'units' in metadata:
+            if metadata['units'] in ['feet', 'foot', 'ft']:
+                metadata = metadata * feet_to_meters
+                metadata['units'] = 'm'
     except:
         metadata = pd.Series()
     return metadata

--- a/stofs-event-dashboard/dashboard.py
+++ b/stofs-event-dashboard/dashboard.py
@@ -163,7 +163,7 @@ def get_model_vars(event) -> list[str]:
     return result
 
 
-@pn.cache
+#  @pn.cache
 def load_data(path: UPath) -> pd.Series[float]:
     """Load data frame from a parquet file."""
     try:
@@ -171,6 +171,69 @@ def load_data(path: UPath) -> pd.Series[float]:
     except:
         df = pd.DataFrame()
     return df
+
+
+#  @pn.cache
+def load_station_metadata() -> pd.Series[float]:
+    """Load station metadata from a json file."""
+    feet_to_meters = 0.3048
+    metadata_path = DATA_DIR.joinpath(
+        UI_storm.storm.value,
+        'station_metadata',
+        f'{UI.station.value}.json'
+    )
+    try:
+        metadata = pd.read_json(metadata_path, 
+                                orient='columns', 
+                                typ='series')
+        metadata = metadata * feet_to_meters
+    except:
+        metadata = pd.Series()
+    return metadata
+
+
+#  @pn.cache
+def get_storm_default_datum(storm: str) -> str:
+    """Get default datum for storm event."""
+    # Try different possible locations for config file.
+    config_paths = [
+        UPath(DATA_DIR, storm, f'{storm}.conf').resolve(),
+        UPath(DATA_DIR, '..', f'{storm}.conf').resolve(),
+        UPath(DATA_DIR, '..', 'conf', f'{storm}.conf').resolve()
+    ]
+    for config_path in config_paths:
+        print('Looking for config file at', config_path)
+        if config_path.exists():
+            with open(config_path) as f:
+                config = json.load(f)
+                output_config = config.get('output', {})
+            storm_datum = output_config.get('output_datum', 'No datum found in config file')
+            if storm_datum == 'NAVD':
+                storm_datum = 'NAVD88'
+            return storm_datum
+    return 'No config file found'
+
+
+def get_flood_levels() -> dict[str, float]:
+    flood_levels = {}
+    st_metadata = load_station_metadata()
+    if UI.datum.value not in st_metadata:
+        return flood_levels
+    if ('nos_minor' in st_metadata) and (~np.isnan(np.float64(st_metadata['nos_minor']))):
+        flood_levels['minor'] = float(st_metadata['nos_minor']) - st_metadata[UI.datum.value]
+    elif ('nws_minor' in st_metadata) and (~np.isnan(np.float64(st_metadata['nws_minor']))):
+        flood_levels['minor'] = float(st_metadata['nws_minor']) - st_metadata[UI.datum.value]
+    if ('nos_moderate' in st_metadata) and (~np.isnan(np.float64(st_metadata['nos_moderate']))):
+        flood_levels['moderate'] = float(st_metadata['nos_moderate']) - st_metadata[UI.datum.value]
+    elif ('nws_moderate' in st_metadata) and (~np.isnan(np.float64(st_metadata['nws_moderate']))):
+        flood_levels['moderate'] = float(st_metadata['nws_moderate']) - st_metadata[UI.datum.value]
+    if ('nos_major' in st_metadata) and (~np.isnan(np.float64(st_metadata['nos_major']))):
+        flood_levels['major'] = float(st_metadata['nos_major']) - st_metadata[UI.datum.value]
+    elif ('nws_major' in st_metadata) and (~np.isnan(np.float64(st_metadata['nws_major']))):
+        flood_levels['major'] = float(st_metadata['nws_major']) - st_metadata[UI.datum.value]
+    print(f'\n\n\n\n\nFlood levels: {flood_levels}\n\n\n\n\n')
+    return flood_levels
+
 
 
 # ----------------------------------------------------------------------------
@@ -183,13 +246,24 @@ def apply_callback(event):
     print(111)
 
 
+def update_storm_datum_display(event):
+    """Callback to update the storm datum display."""
+    datum = get_storm_default_datum(UI_storm.storm.value)
+    UI_storm.storm_default_datum = datum
+    UI_storm.storm_default_datum_display.object = f'Default datum: {datum}'
+
+
 class UI_storm:
     storm = pn.widgets.Select(
         name="Event",
         options=get_event_names()
     )
-    apply_storm = pn.widgets.Button(name="Load event", button_type="primary")
+    storm_default_datum = get_storm_default_datum(storm.value)
+    storm_default_datum_display = pn.pane.Str(f'Default datum: {storm_default_datum}')
+    apply_storm = pn.widgets.Button(name="Load event", 
+                                    button_type="primary")
     apply_storm.on_click(apply_callback)
+    apply_storm.on_click(update_storm_datum_display)
 
 
 class UI:
@@ -205,6 +279,11 @@ class UI:
     station = pn.widgets.Select(
         name="Station",
         options=on_storm_apply(get_all_station_names),
+    )
+    datum = pn.widgets.Select(
+        name="Datum",
+        options=["MSL", "MLLW", "MHHW", "NAVD88"],
+        value="MSL"
     )
     metric = pn.widgets.Select(
         name="Metric",
@@ -238,6 +317,108 @@ class UI_toggle:
         button_style="outline",
         options=on_plot_apply(get_model_vars),
     )
+    
+
+# ----------------------------------------------------------------------------
+# Functions for data handling.
+# ----------------------------------------------------------------------------
+
+def load_obs_sims(
+    storm,
+    plot_type, 
+    forecast_type,
+    models_vars,
+    station,
+    datum
+):  
+    """Load obs and model data.
+
+    Returns
+    -------
+    obs
+        Pandas data frame of observations; empty if none are available.
+    sims
+        Dictionary of form {model_var: DataFrame}
+        Empty if no model data is available for given inputs.
+    """
+    try:
+        # Load obs.
+        obs = load_data(
+            DATA_DIR.joinpath(
+                storm, 
+                plot_type, 
+                'obs', 
+                station +'.parquet'
+            )
+        )
+        if plot_type in ['cwl']:
+            obs = obs.rename(columns={'value':'cwl'})
+        obs = convert_datum(obs, datum)
+        # Load model data.
+        sims = {}
+        for (model,var) in models_vars:
+            df_sim = load_data(
+                DATA_DIR.joinpath(
+                    storm, 
+                    plot_type, 
+                    forecast_type, 
+                    model, 
+                    station + '.parquet'
+                )
+            )
+            df_sim = convert_datum(df_sim, datum)
+            if not df_sim.empty:
+                sims[model + '_' + var] = df_sim.loc[:, var]
+        # Subset if possible.
+        if not obs.empty:
+            obs = obs.iloc[:,0]
+            start, end = obs.index.min(), obs.index.max()
+            sims = {model:ts.loc[start:end] for (model,ts) in sims.items()}
+        return obs, sims
+    except Exception as e:
+        logger.info(f'{storm}: {forecast_type} at {station}: Error while extracting {plot_type} data: {e}')
+        return pd.DataFrame(), {}
+
+
+def convert_datum(df: pd.DataFrame, output_datum: str) -> pd.DataFrame:
+    """Convert datum for data frame columns."""
+    # Get datum for input data frame.
+    if not hasattr(df, 'attrs'):
+        df.attrs = {}
+    if 'ColumnMetaData' not in df.attrs:
+        df.attrs['ColumnMetaData'] = {}
+    for col in df.columns:
+        if (col not in df.attrs['ColumnMetaData']) and \
+            (col in ['cwl', 'cwl_raw', 'cwl_bias_corrected',
+                    'water_level', 'waterlevel', 'htp']):
+            df.attrs['ColumnMetaData'][col] = {}
+        if 'datum' not in df.attrs['ColumnMetaData'][col]:
+            storm_datum = get_storm_default_datum(UI_storm.storm.value)
+            # Add datum to data frame metadata.
+            df.attrs['ColumnMetaData'][col]['datum'] = storm_datum 
+    # Get datum conversion values.
+    stn_metadata = load_station_metadata()
+    # Apply conversions.
+    for col in df.columns:
+        # By this point, any columns that require conversion should have
+        # datum info in their metadata.
+        if 'datum' in df.attrs['ColumnMetaData'][col]:
+            input_datum = df.attrs['ColumnMetaData'][col]['datum']
+            if input_datum != output_datum:
+                try:
+                    # Conversion uses formula:
+                    # height_above_input_datum + input_datum = height_above_output_datum + output_datum
+                    input_datum_value = stn_metadata.get(input_datum.upper(), np.nan)
+                    output_datum_value = stn_metadata.get(output_datum.upper(), np.nan)
+                    # Note that the NaN values mean that no data will be available
+                    # if either of the input datums is not found in the station metadata.
+                    datum_conversion = input_datum_value - output_datum_value
+                    df[col] = df[col] + datum_conversion
+                    # Update datum in data frame metadata.
+                    df.attrs['ColumnMetaData'][col]['datum'] = output_datum
+                except Exception as e:
+                    logger.info(f'Error converting {col} from {input_datum} to {output_datum}: {e}')
+    return df
     
 
 # ----------------------------------------------------------------------------
@@ -388,7 +569,7 @@ def get_folium_map():
 def get_plot_label(plot_type: str) -> str:
     """Get plot axis label with units."""
     if plot_type in ['cwl']:
-        return 'water elevation (m)'
+        return f'water elevation (m, {UI.datum.value})'
     elif plot_type in ['pressure']:
         return 'surface air pressure (hPa)'
     elif plot_type in ['wind']:
@@ -396,58 +577,7 @@ def get_plot_label(plot_type: str) -> str:
     else:
         logger.info(f'No plot label for plot_type {plot_type}.')
         return ''
-
-
-def load_obs_sims(
-    storm,
-    plot_type, 
-    forecast_type,
-    models_vars,
-    station
-):  
-    """Load obs and model data.
-
-    Returns
-    -------
-    obs
-        Pandas data frame of observations; empty if none are available.
-    sims
-        Dictionary of form {model_var: DataFrame}
-        Empty if no model data is available for given inputs.
-    """
-    try:
-        # Load obs.
-        obs = load_data(
-            DATA_DIR.joinpath(
-                storm, 
-                plot_type, 
-                'obs', 
-                station +'.parquet'
-            )
-        )
-        # Load model data.
-        sims = {}
-        for (model,var) in models_vars:
-            df_sim = load_data(
-                DATA_DIR.joinpath(
-                    storm, 
-                    plot_type, 
-                    forecast_type, 
-                    model, 
-                    station + '.parquet'
-                )
-            )
-            if not df_sim.empty:
-                sims[model + '_' + var] = df_sim.loc[:, var]
-        # Subset if possible.
-        if not obs.empty:
-            obs = obs.iloc[:,0]
-            start, end = obs.index.min(), obs.index.max()
-            sims = {model:ts.loc[start:end] for (model,ts) in sims.items()}
-        return obs, sims
-    except Exception as e:
-        logger.info(f'{storm}: {forecast_type} at {station}: Error while extracting {plot_type} data: {e}')
-        return pd.DataFrame(), {}
+    
     
 def plot_ts(event):
     quantile = UI.quantile.value / 100
@@ -461,7 +591,8 @@ def plot_ts(event):
             UI.plot_type.value, 
             UI.forecast_type.value, 
             UI_toggle.models_vars.value, 
-            UI.station.value
+            UI.station.value,
+            UI.datum.value
         )
         # Plot obs (if available).
         if not obs.empty:
@@ -484,6 +615,18 @@ def plot_ts(event):
         # If obs and/or model available, plot them;
         # otherwise, return a "No Data" message.
         if timeseries:
+            # Get flood levels too, if available.
+            try:
+                flood_levels = get_flood_levels()
+                flood_colors = {'minor':'#fd8d3c', 'moderate':'#f03b20', 'major':'#800080'}
+                for level, value in flood_levels.items():
+                    timeseries += [hv.HLine(value).opts(
+                        color=flood_colors.get(level, "red"), 
+                        line_dash="dotted", 
+                        line_width=1
+                    )]
+            except Exception as e:
+                logger.info(f'Error while getting flood levels: {e}')
             return hv.Overlay(timeseries).opts(show_grid=True, active_tools=["box_zoom"], min_height=300, ylabel=ylabel, title=title)
         else:
             return pn.pane.Str(f'{title}: No {UI.plot_type.value} time series data.')
@@ -502,7 +645,8 @@ def plot_table_comparison(event):
             UI.plot_type.value, 
             UI.forecast_type.value, 
             UI_toggle.models_vars.value, 
-            UI.station.value
+            UI.station.value,
+            UI.datum.value
         )
         if (not obs.empty) & (len(sims) > 0):
             # Do separate storm and general stats calculations because
@@ -548,7 +692,8 @@ def plot_scatter(event):
             UI.plot_type.value, 
             UI.forecast_type.value, 
             UI_toggle.models_vars.value, 
-            UI.station.value
+            UI.station.value,
+            UI.datum.value
         )
         # Need both obs and model for this plot.
         if (not obs.empty) & (len(sims) > 0):
@@ -602,7 +747,8 @@ def plot_extremes_table(event):
             UI.plot_type.value, 
             UI.forecast_type.value, 
             UI_toggle.models_vars.value, 
-            UI.station.value
+            UI.station.value,
+            UI.datum.value
         )
         model_dfs = []
         for i, (model, sim) in enumerate(sims.items()):
@@ -686,12 +832,14 @@ def get_page():
         sidebar=[
             pn.pane.Str('\nEvent'),
             UI_storm.storm,
+            UI_storm.storm_default_datum_display,
             UI_storm.apply_storm,
             pn.pane.Str('\n\nData'),
             UI.plot_type,
             UI.forecast_type,
             UI.station,
             UI_toggle.models_vars,
+            UI.datum,
             pn.pane.Str('\n\nStatistics'),
             #UI.metric,
             UI.quantile,

--- a/stofs-event-dashboard/dashboard.py
+++ b/stofs-event-dashboard/dashboard.py
@@ -418,6 +418,8 @@ def convert_datum(df: pd.DataFrame, output_datum: str) -> pd.DataFrame:
         # datum info in their metadata.
         if 'datum' in df.attrs['ColumnMetaData'][col]:
             input_datum = df.attrs['ColumnMetaData'][col]['datum']
+            if input_datum == 'LMSL':
+                input_datum = 'MSL'
             if input_datum != output_datum:
                 try:
                     # Conversion uses formula:

--- a/stofs-event-dashboard/models.py
+++ b/stofs-event-dashboard/models.py
@@ -474,6 +474,9 @@ def query_and_save_model(
         if run_query:
             try:
                 model_data['wind_speed'] = np.sqrt(model_data['u10']**2 + model_data['v10']**2)
+                model_data.attrs['ColumnMetaData']['wind_speed'] = model_data.attrs['ColumnMetaData']['u10'].copy()
+                model_data.attrs['ColumnMetaData']['wind_speed']['long_name'] = 'wind speed calculated from U and V components'
+                model_data.attrs['ColumnMetaData']['wind_speed']['short_name'] = 'wind_speed_10maboveground'
                 save_cols = model_config['wind_var_list'] + ['wind_speed']
             except:
                 logger.warning('Unable to calculate wind speed from u10 and v10 variables.')
@@ -489,6 +492,7 @@ def query_and_save_model(
         if run_query:
             try:
                 model_data['ps'] = model_data['ps'] / 100.0
+                model_data.attrs['ColumnMetaData']['ps']['units'] = 'hPa'
             except:
                 logger.warning('Unable to convert pressure to hPa.')
             write_output.df_sealens_parquet(

--- a/stofs-event-dashboard/process-event-data.py
+++ b/stofs-event-dashboard/process-event-data.py
@@ -78,7 +78,6 @@ def process_event(config: dict) -> None:
          'met':met_stations},
         config['output']
     )
-    import pdb; pdb.set_trace()
 
     # ---------- Observations. ------------------------------
     # TODO: Move the obs network checks to the station_obs module.

--- a/stofs-event-dashboard/process-event-data.py
+++ b/stofs-event-dashboard/process-event-data.py
@@ -11,24 +11,22 @@ E.g.,
 
 import argparse
 import json
-import sys
 import os
 import logging
 import traceback
-import shapely
-import searvey
 import pandas as pd
 import geopandas as gpd
 import numpy as np
 import pathlib
 import datetime
-import time
-import asyncio
 from seanode.api import get_surge_model_at_stations
 import space_time_bounds
-from station_obs import fetch_metadata, save_obs
+from station_obs import (
+    fetch_metadata, 
+    save_obs,
+    save_coops_datums_flood_levels
+)
 from models import (
-    get_forecast_init_times, 
     save_model
 )
 import map_data
@@ -66,11 +64,22 @@ def process_event(config: dict) -> None:
     # Or do this within fetch_metadata?
     
     # Save map data in geopackage.
-    map_data.save_geopackage(stb, 
-                             {'waterlevel':waterlevel_stations, 
-                              'met':met_stations},
-                             config['output'])
+    map_data.save_geopackage(
+        stb, 
+        {'waterlevel':waterlevel_stations, 
+        'met':met_stations},
+        config['output']
+    )
     
+    # Save station metadata.
+    save_coops_datums_flood_levels(
+        stb, 
+        {'waterlevel':waterlevel_stations, 
+         'met':met_stations},
+        config['output']
+    )
+    import pdb; pdb.set_trace()
+
     # ---------- Observations. ------------------------------
     # TODO: Move the obs network checks to the station_obs module.
     if "coops" in config['stations']['source_list']:

--- a/stofs-event-dashboard/station_obs.py
+++ b/stofs-event-dashboard/station_obs.py
@@ -22,6 +22,7 @@ from searvey._coops_api import fetch_coops_station
 from typing import Iterable, Union, Any
 from space_time_bounds import eventSpaceTimeBounds
 import write_output 
+from coops_md.fetch_coops_metadata import save_station_levels_json
 
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,26 @@ def fetch_coops_metadata(
         (station_list['station_type'] == 'met')
     ]
     return (waterlevel_stations, met_stations)
+
+
+def save_coops_datums_flood_levels(
+    stb: eventSpaceTimeBounds, 
+    station_df_dict: dict, 
+    output_config: dict
+):
+    """Fetch CO-OPS datums and flood levels."""
+    data_dir = write_output.get_output_dir(output_config, stb)
+    out_dir = pathlib.Path(data_dir) / 'station_metadata'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for df in station_df_dict.values():
+        for st in df.loc[df.station_id_type == 'NOS', 'station']:
+            logger.debug(f'Fetching CO-OPS datums and flood levels for station {st}.')
+            try:
+                json_path = out_dir / f'nos_{st}.json'
+                save_station_levels_json(st, json_path)
+            except Exception as e:
+                logger.warning(f'Error fetching CO-OPS datums and flood levels for station {st}: {e}')
+    return 
 
 
 def fetch_ioc_metadata(


### PR DESCRIPTION
Adds datum conversion and flood levels to the dashboard. Note that this interfaces with `seanode` changes that add metadata attributes to the output data frames. 

Several major components:
1. Metadata saved in model and observations parquet files.
2. Station datum offsets and flood levels saved in JSON files.
3. Front end modified to read the metadata from (1), (2), and config files, and modify water levels to different datums on the fly.